### PR TITLE
Remove NSP checks from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,9 @@ before_install:
   - npm install -g npm@2.13.5
   - npm install -g grunt@0.4.5
   - npm install -g grunt-cli
-  - npm install -g nsp
 install: npm install
 script:
   - npm test
-  - nsp check; exit 0
   - >-
     bash <(curl
     https://gist.githubusercontent.com/raincatcher-bot/01ac4cdb3b0770bdb58489dbc17ed6b6/raw/6205a628c3616f6736fd866d5f0fba0a781ec1e4/sonarqube.sh)


### PR DESCRIPTION
- These are no longer necessary as Snyk is being used for security checks on PR's.